### PR TITLE
version: 1.0.1 -> 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ checksum = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 
 [[package]]
 name = "nixdoc"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "failure",
  "rnix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nixdoc"
-version = "1.0.1"
-authors = ["Vincent Ambo <mail@tazj.in>"]
+version = "2.0.0"
+authors = ["Vincent Ambo <mail@tazj.in>", "asymmetric"]
 
 [dependencies]
 xml-rs = "0.8"

--- a/flake.nix
+++ b/flake.nix
@@ -10,11 +10,14 @@
   };
   outputs = { self, nixpkgs, flake-compat, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = nixpkgs.legacyPackages.${system}; in
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        package = (pkgs.lib.importTOML ./Cargo.toml).package;
+      in
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
-          pname = "nixdoc";
-          version = "1.0.1";
+          pname = package.name;
+          version = package.version;
           src = ./.;
 
           cargoLock = {
@@ -28,7 +31,7 @@
 
         apps.default = flake-utils.lib.mkApp {
           drv = self.packages.${system}.default;
-          name = "nixdoc";
+          name = package.name;
         };
 
         devShells.default = pkgs.mkShell {


### PR DESCRIPTION
A major version bump seems warranted, since we changed the output format from DocBook to CommonMark.