### PR TITLE
deps: remove unused xml-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,6 @@ dependencies = [
  "serde_json",
  "structopt",
  "textwrap 0.16.0",
- "xml-rs",
 ]
 
 [[package]]
@@ -631,12 +630,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "xml-rs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "2.3.0"
 authors = ["Vincent Ambo <mail@tazj.in>", "asymmetric"]
 
 [dependencies]
-xml-rs = "0.8"
 structopt = "0.2"
 failure = "0.1"
 rnix = "0.11"


### PR DESCRIPTION
It was probably left behind when switching to CommonMark.