### PR TITLE
cargo: switch to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nixdoc"
 version = "2.3.0"
 authors = ["Vincent Ambo <mail@tazj.in>", "asymmetric"]
+edition = "2021"
 
 [dependencies]
 structopt = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,10 +21,6 @@
 //! * extract line number & add it to generated output
 //! * figure out how to specify examples (& leading whitespace?!)
 
-extern crate rnix;
-extern crate rowan;
-extern crate structopt;
-
 mod commonmark;
 
 use self::commonmark::*;


### PR DESCRIPTION
Mainly to remove `extern crate` statements, and because there don't seem to be any downsides.