### PR TITLE
Only render multiline-comments as descriptions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -401,7 +401,7 @@ fn retrieve_description(nix: &rnix::Root, description: &str, category: &str) -> 
         category,
         &nix.syntax()
             .first_child()
-            .and_then(|node| retrieve_doc_comment(&node, true))
+            .and_then(|node| retrieve_doc_comment(&node, false))
             .and_then(|comment| handle_indentation(&comment))
             .unwrap_or_default()
     )


### PR DESCRIPTION
This should not render the "Some text":

    # Some
    # text
    {
      foo = ...;
    }

Only this should:

    /*
      Some
      text
    */
    {
      foo = ...;
    }

This aligns with single-line comments being ignored for functions too.

Ping @phaer, since it was originally introduced in #70 