### PR TITLE
feat: support custom prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.7.0
+
+- Added support to customise the attribute set prefix, which was previously hardcoded to `lib`.
+  The default is still `lib`, but you can pass `--prefix` now to use something else like `utils`.
+
+  By @Janik-Haag in https://github.com/nix-community/nixdoc/pull/97
+
 ## 2.6.0
 
 - After doing a great job of maintaining the project for this year, @asymmetric is passing on the torch to @infinisil!

--- a/src/commonmark.rs
+++ b/src/commonmark.rs
@@ -102,6 +102,9 @@ fn handle_indentation(raw: &str) -> String {
 /// Represents a single manual section describing a library function.
 #[derive(Clone, Debug)]
 pub struct ManualEntry {
+    /// Prefix for the category (e.g. 'lib' or 'utils').
+    pub prefix: String,
+
     /// Name of the function category (e.g. 'strings', 'trivial', 'attrsets')
     pub category: String,
 
@@ -130,9 +133,10 @@ impl ManualEntry {
         locs: &HashMap<String, String>,
         writer: &mut W,
     ) -> Result<()> {
-        let title = format!("lib.{}.{}", self.category, self.name);
+        let title = format!("{}.{}.{}", self.prefix, self.category, self.name);
         let ident = format!(
-            "lib.{}.{}",
+            "{}.{}.{}",
+            self.prefix,
             self.category,
             self.name.replace('\'', "-prime")
         );


### PR DESCRIPTION
This adds the ability to define a custom prefix like `lib` or  `utils` which is currently hardcoded.
~~Sadly this will be probably be a breaking change since I didn't see a way to set default values for arguments~~
The only thing missing from this PR I can think of would be a CHANGELOG.md entry. 