### PR TITLE
args: omit all lamda args. To force explizit documentation of them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 3.0.2
+
+Avoid displaying arguments when a doc-comment is already in place.
+
+by @hsjobeki;
+
+in https://github.com/nix-community/nixdoc/pull/109.
+
 ## Version 3.0.1
 
 ### New Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "nixdoc"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "clap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nixdoc"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Vincent Ambo <mail@tazj.in>", "asymmetric"]
 edition = "2021"
 description = "Generate CommonMark from Nix library functions"

--- a/src/snapshots/nixdoc__test__doc_comment.snap
+++ b/src/snapshots/nixdoc__test__doc_comment.snap
@@ -20,41 +20,6 @@ This is a parsed example
 
 doc comment in markdown format
 
-## `lib.debug.argumentTest` {#function-library-lib.debug.argumentTest}
-
-doc comment in markdown format
-
-### Example (Should be a heading)
-
-This is just markdown
-
-Type: (Should NOT be a heading)
-
-This is just markdown
-
-structured function argument
-
-: `formal1`
-
-  : Legacy line comment
-
-  `formal2`
-
-  : Legacy Block
-
-  `formal3`
-
-  : Legacy 
-    multiline
-    comment
-
-  `formal4`
-
-  : official doc-comment variant
-
-
 ## `lib.debug.foo` {#function-library-lib.debug.foo}
 
 Comment
-
-

--- a/src/snapshots/nixdoc__test__doc_comment_no_duplicate_arguments.snap
+++ b/src/snapshots/nixdoc__test__doc_comment_no_duplicate_arguments.snap
@@ -1,0 +1,53 @@
+---
+source: src/test.rs
+expression: output
+---
+# Debug {#sec-functions-library-debug}
+
+
+## `lib.debug.old` {#function-library-lib.debug.old}
+
+nixdoc comment
+
+`arg`
+
+: Should be visible
+
+
+## `lib.debug.omited` {#function-library-lib.debug.omited}
+
+Doc-comment
+
+## `lib.debug.multiple` {#function-library-lib.debug.multiple}
+
+Doc-comment
+
+## `lib.debug.argumentTest` {#function-library-lib.debug.argumentTest}
+
+Doc-comment before the lamdba causes the whole 
+lambda including its arguments to switch to doc-comments ONLY rendering
+
+## `lib.debug.legacyArgumentTest` {#function-library-lib.debug.legacyArgumentTest}
+
+Legacy comments allow to use any 
+form of comments for the lambda arguments/formals
+
+structured function argument
+
+: `formal1`
+
+  : Legacy line comment
+
+  `formal2`
+
+  : Legacy Block
+
+  `formal3`
+
+  : Legacy 
+    multiline
+    comment
+
+  `formal4`
+
+  : doc-comment style

--- a/src/test.rs
+++ b/src/test.rs
@@ -179,3 +179,24 @@ fn test_doc_comment_section_description() {
 
     insta::assert_snapshot!(output);
 }
+
+#[test]
+fn test_doc_comment_no_duplicate_arguments() {
+    let mut output = Vec::new();
+    let src = fs::read_to_string("test/doc-comment-arguments.nix").unwrap();
+    let nix = rnix::Root::parse(&src).ok().expect("failed to parse input");
+    let prefix = "lib";
+    let category = "debug";
+    let desc = retrieve_description(&nix, &"Debug", category);
+    writeln!(output, "{}", desc).expect("Failed to write header");
+
+    for entry in collect_entries(nix, prefix, category) {
+        entry
+            .write_section(&Default::default(), &mut output)
+            .expect("Failed to write section")
+    }
+
+    let output = String::from_utf8(output).expect("not utf8");
+
+    insta::assert_snapshot!(output);
+}

--- a/test/doc-comment-arguments.nix
+++ b/test/doc-comment-arguments.nix
@@ -1,0 +1,69 @@
+{
+  /* nixdoc comment */
+  old = 
+  # Should be visible
+  arg: 1;
+  
+  /** Doc-comment */
+  omited = 
+  # Not visible
+  arg: 1; 
+
+  /** Doc-comment */
+  multiple = 
+  # Not visible
+  arg:
+  /* Not visible */ 
+  foo:
+  /** Not visible */
+  bar:
+  1;
+
+  /** 
+    Doc-comment before the lamdba causes the whole 
+    lambda including its arguments to switch to doc-comments ONLY rendering
+  */
+    argumentTest = {
+    # Legacy line comment
+    formal1,
+    # Legacy 
+    # Block
+    formal2,
+    /*
+    Legacy 
+    multiline
+    comment
+    */
+    formal3,
+    /**
+    Not shown yet
+    */
+    formal4,
+
+  }: 
+  {};
+
+  /*
+    Legacy comments allow to use any 
+    form of comments for the lambda arguments/formals
+  */
+  legacyArgumentTest = {
+    # Legacy line comment
+    formal1,
+    # Legacy 
+    # Block
+    formal2,
+    /*
+    Legacy 
+    multiline
+    comment
+    */
+    formal3,
+    /**
+    doc-comment style
+    */
+    formal4,
+
+  }: 
+  {};
+}

--- a/test/doc-comment.nix
+++ b/test/doc-comment.nix
@@ -20,37 +20,6 @@
   */
   rfc-style = {};
 
-  /**
-  doc comment in markdown format
-
-  # Example (Should be a heading)
-
-  This is just markdown
-
-  Type: (Should NOT be a heading)
-
-  This is just markdown
-  */
-  argumentTest = {
-    # Legacy line comment
-    formal1,
-    # Legacy 
-    # Block
-    formal2,
-    /*
-    Legacy 
-    multiline
-    comment
-    */
-    formal3,
-    /**
-    official doc-comment variant
-    */
-    formal4,
-
-  }: 
-  {};
-
   # Omitting a doc comment from an attribute doesn't duplicate the previous one 
   /** Comment */
   foo = 0;


### PR DESCRIPTION
This fixes a problem, that arose during the migration to doc-comments.

@danielSidhion and me already started migrating to doc-comments (lib.asserts is already migrated), and encountering having arguments double documented. Just deleting the adjacent comments can't fix this.

With this PR we can assume arguments are documented explicitly in the lambda documentation as:

```nix
{

/** 
# Inputs

foo

: some foo docs

*/
f = foo: 1;

}
``` 

The issue is, that we automatically create empty default documentation for non documented arguments. (which is fine for the legacy path)

I've found it fine to assume that having a doc-comment is enough to assume that there is no need to magically add argument documentation for now, since the doc-comment should already includes those.

At a later point in time, we may add argument documentation for doc-comments as well. Because we specified them for lambda formals (structured arguments) I am still working on the roadmap how to integrate them.