### PR TITLE
init: frontmatter support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +149,26 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.3",
+]
 
 [[package]]
 name = "insta"
@@ -194,7 +226,9 @@ dependencies = [
  "rowan",
  "serde",
  "serde_json",
+ "serde_yaml 0.9.33",
  "textwrap",
+ "yaml-front-matter",
 ]
 
 [[package]]
@@ -231,7 +265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a58fa8a7ccff2aec4f39cc45bf5f985cec7125ab271cf681c279fd00192b49"
 dependencies = [
  "countme",
- "hashbrown",
+ "hashbrown 0.14.3",
  "memoffset",
  "rustc-hash",
  "text-size",
@@ -278,6 +312,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+dependencies = [
+ "indexmap 1.9.3",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
+dependencies = [
+ "indexmap 2.2.5",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -343,6 +402,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"
@@ -415,6 +480,16 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "yaml-front-matter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94fb32d2b438e3fddf901fbfe9eb87b34d63853ca6c6da5d2ab7e27031e0bae"
+dependencies = [
+ "serde",
+ "serde_yaml 0.8.26",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 textwrap = "0.16"
 clap = { version = "4.4.4", features = ["derive"] }
+serde_yaml = "0.9.33"
+yaml-front-matter = "0.1.0"
 
 [dev-dependencies]
 insta = "1.36.1"

--- a/doc/frontmatter.md
+++ b/doc/frontmatter.md
@@ -1,0 +1,96 @@
+# Frontmatter
+
+This document is the specification for custom metadata within doc-comments.
+
+It should only apply to doc-comments (`/** */`) and not to regular code comments to ensure a limited scope.
+
+## Why frontmatter is needed (sometimes)
+
+Sometimes it is desireable to extend the native doc-comment functionality. For that user scenario, frontmatter can be optionally used.
+
+i.e.,
+
+- Enriching documentation generation.
+- Maintaining References.
+- Metadata inclusion.
+- Allow better Handling of edge cases.
+
+## Detailed design
+
+Fields (from Keywords list) can be defined in frontmatter.
+
+Frontmatter is defined using key-value pairs, encapsulated within triple-dashed lines (---).
+
+While there is no strict specification for frontmatter formats, YAML is commonly preferred. Although JSON could also be used alternatively.
+
+`{key}` is a placeholder for the list of available keywords listed below.
+
+`{value}` is a placeholder for the set value associated with the directive.
+
+Example:
+
+```nix
+{
+/** 
+  ---
+  import: ./path.md
+  ---
+*/
+foo = x: x;
+}
+```
+
+In this example, the `import` directive fetches content from `./path.md` treating it as if it were directly within the doc-comment.
+This allows tracking the reference between the source position and the markdown file, in case of extensive documentation.
+
+## Keywords
+
+### Import
+
+Rules:
+
+1. The `import` keyword can be used to use content from another file INSTEAD of the doc-comments content.
+
+2. The value `file` must be given as an absolute path (relative to git root) or relative to the current file.
+
+3. There can only be one `import` per doc-comment.
+
+```nix
+{
+/** 
+ ---
+ import: ./path.md
+ ---
+*/
+foo = x: x;
+}
+```
+
+`path.md`
+```md
+some nice docs!
+```
+
+Rendering this would behave as if the content where actually placed in the doc-comment itself.
+
+Placing frontmatter inside the imported file will be ignored. (No nested directives)
+Since handling recursive or nested imports adds too much complexity for little or no benefit.
+
+> Note: Absolute path imports are relative to the repository root. They only work inside `git` repositories and require having the `git` binary in PATH.
+> This is most commonly used in large repositories or when the documentation files are not placed alongside the .nix files.
+
+## Extensibility
+
+The initial set of keywords is intentionally minimalistic,
+focusing on immediate and broadly applicable needs.
+
+Community contributions are encouraged to expand this list as new use cases emerge.
+
+## Error handling
+
+Any issues encountered during the processing of frontmatter—be it syntax errors, invalid paths, or unsupported keywords—should result in clear, actionable error messages to the user.
+
+## Future work
+
+This proposal represents a foundational step towards more versatile and extendable reference documentation.
+As we move forward, we'll remain open to adapting and expanding this specification to meet emerging needs and leverage community insights.

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -1,0 +1,60 @@
+use std::{collections::HashMap, fs, path::PathBuf, process::Command};
+
+use serde::{Deserialize, Serialize};
+use yaml_front_matter::{Document, YamlFrontMatter};
+
+fn find_repo_root() -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(&["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?
+        .stdout;
+
+    let path_str = String::from_utf8(output).ok()?.trim().to_string();
+    Some(PathBuf::from(path_str))
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct Matter {
+    #[serde(flatten)]
+    pub content: HashMap<String, serde_yaml::Value>,
+}
+
+/// Returns the actual content of a markdown file, if the frontmatter has an import field.
+pub fn get_imported_content(file_path: &PathBuf, markdown: Option<&String>) -> Option<String> {
+    if markdown.is_none() {
+        return None;
+    }
+
+    match YamlFrontMatter::parse::<Matter>(&markdown.unwrap()) {
+        Ok(document) => {
+            let metadata = document.metadata.content;
+
+            let abs_import = metadata.get("import").map(|field| {
+                let import_val = field
+                    .as_str()
+                    .expect("Frontmatter: import field must be a string");
+                match PathBuf::from(import_val).is_relative() {
+                    true => PathBuf::from_iter(vec![
+                        // Cannot fail because every file has a parent directory
+                        file_path.parent().unwrap().to_path_buf(),
+                        PathBuf::from(import_val),
+                    ]),
+                    false => PathBuf::from_iter(vec![
+                        find_repo_root()
+                        .expect("Could not find root directory of repository. Make sure you have git installed and are in a git repository"),
+                        PathBuf::from(format!(".{import_val}")),
+                    ]),
+                }
+            });
+
+            abs_import.map(|path| {
+                fs::read_to_string(&path)
+                    .expect(format!("Could not read file: {:?}", &path).as_str())
+            })
+        }
+        Err(e) => {
+            return None;
+        }
+    }
+}


### PR DESCRIPTION
### Add support for frontmatter

### Why frontmatter is needed (sometimes)

Sometimes it is desireable to extend the content with meta information. Frontmatter is the de-facto standard of adding document specific meta tags to markdown. [1](https://docs.github.com/en/contributing/writing-for-github-docs/using-yaml-frontmatter) [2](https://jekyllrb.com/docs/front-matter/) [3](https://starlight.astro.build/reference/frontmatter/)

This would allow us to keep track of references between documents that are closely related to nix code or externalized doc-comments that are no longer tracked.

This PR also includes a detailed [design document](/doc/frontmatter.md). 

i.e.,

- Enriching documentation generation.
- Maintaining References.
- Metadata inclusion.
- Allow better Handling of edge cases.

### Example

```nix
{
/** 
 ---
 import: ./path.md
 ---
*/
foo = x: x;
}
```

## TODO

- [ ] Unit tests
- [ ] Bump version
- [ ] Manual testing with nixpkgs/nixos manuals