### PR TITLE
fix: headings with ids get escaped by comrak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 3.0.4
+
+Fixes: issue with headings ids introduced with 3.0.3
+
+by @hsjobeki;
+
+in https://github.com/nix-community/nixdoc/pull/117.
+
 ## Version 3.0.3
 
 Fixes: shifting issue with commonmark headings https://github.com/nix-community/nixdoc/issues/113

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "nixdoc"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "clap",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nixdoc"
-version = "3.0.3"
+version = "3.0.4"
 authors = ["Vincent Ambo <mail@tazj.in>", "asymmetric"]
 edition = "2021"
 description = "Generate CommonMark from Nix library functions"

--- a/src/format.rs
+++ b/src/format.rs
@@ -20,11 +20,13 @@ impl<'a> CustomRenderer<'a> {
         for node in root.children() {
             match &node.data.borrow().value {
                 NodeValue::Heading(heading) => {
-                    // Handling headings specifically
+                    // Handling headings specifically.
                     write!(buffer, "{} ", "#".repeat(heading.level as usize)).expect(
                         "Failed to write UTF-8. Make sure files contains only valid UTF-8.",
                     );
 
+                    // Handle the children of the heading node
+                    // Headings have only one child: NodeValue::Text
                     node.first_child()
                         .map(|child| match child.data.borrow().value {
                             NodeValue::Text(ref text) => {
@@ -37,6 +39,8 @@ impl<'a> CustomRenderer<'a> {
                 _ => format_commonmark(node, self.options, buffer)
                     .expect("Failed to format markdown using the default comrak formatter."),
             }
+            // Insert a newline after each node
+            // This behavior is the same as the default comrak-formatter behavior.
             buffer.push(b'\n');
         }
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -27,18 +27,21 @@ impl<'a> CustomRenderer<'a> {
 
                     // Handle the children of the heading node
                     // Headings have only one child: NodeValue::Text
-                    node.first_child()
-                        .map(|child| match child.data.borrow().value {
-                            NodeValue::Text(ref text) => {
-                                write!(buffer, "{}\n", text).expect("Failed to write UTF-8. Make sure files contains only valid UTF-8.");
-                            }
-                            _ => (),
-                        });
+                    if let Some(child) = node.first_child() {
+                        if let NodeValue::Text(ref text) = child.data.borrow().value {
+                            writeln!(buffer, "{}", text).expect(
+                                "Failed to write UTF-8. Make sure files contains only valid UTF-8.",
+                            );
+                        };
+                    }
                 }
                 // Handle other node types using comrak's default behavior
-                _ => format_commonmark(node, self.options, buffer)
-                    .expect("Failed to format markdown using the default comrak formatter."),
-            }
+                _ => {
+                    format_commonmark(node, self.options, buffer)
+                        .expect("Failed to format markdown using the default comrak formatter.");
+                }
+            };
+
             // Insert a newline after each node
             // This behavior is the same as the default comrak-formatter behavior.
             buffer.push(b'\n');

--- a/src/snapshots/nixdoc__test__doc_comment.snap
+++ b/src/snapshots/nixdoc__test__doc_comment.snap
@@ -21,6 +21,7 @@ This is a parsed example
 doc comment in markdown format
 
 
+
 ## `lib.debug.foo` {#function-library-lib.debug.foo}
 
 Comment

--- a/src/snapshots/nixdoc__test__doc_comment_no_duplicate_arguments.snap
+++ b/src/snapshots/nixdoc__test__doc_comment_no_duplicate_arguments.snap
@@ -19,15 +19,18 @@ nixdoc comment
 Doc-comment
 
 
+
 ## `lib.debug.multiple` {#function-library-lib.debug.multiple}
 
 Doc-comment
+
 
 
 ## `lib.debug.argumentTest` {#function-library-lib.debug.argumentTest}
 
 Doc-comment before the lamdba causes the whole
 lambda including its arguments to switch to doc-comments ONLY rendering
+
 
 
 ## `lib.debug.legacyArgumentTest` {#function-library-lib.debug.legacyArgumentTest}

--- a/src/snapshots/nixdoc__test__headings.snap
+++ b/src/snapshots/nixdoc__test__headings.snap
@@ -6,6 +6,8 @@ expression: output
 
 #### h2-heading
 
+#### h2-heading-with-id {#some-id}
+
 ##### h3-heading
 
 ``` nix

--- a/test/headings.md
+++ b/test/headings.md
@@ -2,6 +2,8 @@
 
 ## h2-heading
 
+## h2-heading-with-id {#some-id}
+
 ### h3-heading
 
 ```nix


### PR DESCRIPTION
The problem was that headings with id got escaped by the default formatter of comrak.

`# heading {#some-id}` -> `# heading {\#some-id}`

Unfortunately it seems there is no option or other crate that allows easy bi-directional serializing of common mark.

All other options i investigated require an incredible amount of work. (i.e. pulldown-cmark requires wiriting a complete engine, that handle all ast cases and sub node cases)

I fixed that issue now by implementing a custom formatter, that uses comrak::format_commonmark for all nodes except for headings.



Fixes: https://github.com/NixOS/nixpkgs/pull/303330.