### PR TITLE
Fix/headings & check: nixdoc can always build nixpks manual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 3.0.5
+
+Fixes: incompatibility with nixpkgs in 3.0.3 and 3.0.4
+
+by @hsjobeki;
+
+in https://github.com/nix-community/nixdoc/pull/121.
+
 ## Version 3.0.4
 
 Fixes: issue with headings ids introduced with 3.0.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,7 +37,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -62,7 +47,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -70,66 +55,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
-
-[[package]]
-name = "bumpalo"
-version = "3.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
-
-[[package]]
-name = "cc"
-version = "1.0.90"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -150,8 +75,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.0",
- "terminal_size",
+ "strsim",
 ]
 
 [[package]]
@@ -163,7 +87,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn",
 ]
 
 [[package]]
@@ -179,26 +103,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "comrak"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0436149c9f6a1935b13306206c739b1ba84fa81f551b5eb87fc2ca7a13700af"
-dependencies = [
- "clap",
- "derive_builder",
- "entities",
- "memchr",
- "once_cell",
- "regex",
- "shell-words",
- "slug",
- "syntect",
- "typed-arena",
- "unicode_categories",
- "xdg",
-]
-
-[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,7 +111,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -217,148 +121,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
-name = "crc32fast"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
-dependencies = [
- "derive_builder_core",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "deunicode"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e854126756c496b8c81dec88f9a706b15b875c5849d4097a3854476b9fdf94"
-
-[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "entities"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
-
-[[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "errno"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "fancy-regex"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
-dependencies = [
- "bit-set",
- "regex",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "hashbrown"
@@ -371,22 +137,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "indexmap"
-version = "2.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
 
 [[package]]
 name = "insta"
@@ -419,34 +169,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
-name = "line-wrap"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1bc4d24ad230d21fb898d1116b1801d7adfc449d42026475862ab48b11e70e"
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
-
-[[package]]
-name = "log"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-
-[[package]]
-name = "memchr"
-version = "2.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memoffset"
@@ -458,20 +184,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
-dependencies = [
- "adler",
-]
-
-[[package]]
 name = "nixdoc"
 version = "3.0.4"
 dependencies = [
  "clap",
- "comrak",
  "insta",
  "rnix",
  "rowan",
@@ -479,66 +195,6 @@ dependencies = [
  "serde_json",
  "textwrap",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "once_cell"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "onig"
-version = "6.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "plist"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d34169e64b3c7a80c8621a48adaf44e0cf62c78a9b25dd9dd35f1881a17cf9"
-dependencies = [
- "base64",
- "indexmap",
- "line-wrap",
- "quick-xml",
- "serde",
- "time",
-]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -550,15 +206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,35 +213,6 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "regex"
-version = "1.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rnix"
@@ -625,32 +243,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustix"
-version = "0.38.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
-dependencies = [
- "bitflags 2.5.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "serde"
@@ -669,7 +265,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn",
 ]
 
 [[package]]
@@ -684,26 +280,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
-
-[[package]]
 name = "similar"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
-
-[[package]]
-name = "slug"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd94acec9c8da640005f8e135a39fc0372e74535e6b368b7a04b875f784c8c4"
-dependencies = [
- "deunicode",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "smawk"
@@ -713,26 +293,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -743,39 +306,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syntect"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
-dependencies = [
- "bincode",
- "bitflags 1.3.2",
- "fancy-regex",
- "flate2",
- "fnv",
- "once_cell",
- "onig",
- "plist",
- "regex-syntax",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror",
- "walkdir",
- "yaml-rust",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
-dependencies = [
- "rustix",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -796,63 +326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.52",
-]
-
-[[package]]
-name = "time"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,120 +344,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.52",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.52",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "windows-sys"
@@ -992,22 +355,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1016,20 +364,14 @@ version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1039,21 +381,9 @@ checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1063,21 +393,9 @@ checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1087,39 +405,12 @@ checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
-
-[[package]]
-name = "xdg"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 textwrap = "0.16"
 clap = { version = "4.4.4", features = ["derive"] }
-comrak = "0.22.0"
 
 [dev-dependencies]
 insta = "1.38.0"

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,14 @@
   outputs = { self, nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
+        nixpkgsDocs = import "${nixpkgs}/doc" { 
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ 
+              (_: _: { nixdoc = self.packages.${system}.default; } )
+            ];
+          }; 
+        };
         pkgs = nixpkgs.legacyPackages.${system};
         package = (pkgs.lib.importTOML ./Cargo.toml).package;
       in
@@ -31,6 +39,7 @@
         };
 
         checks = {
+          inherit nixpkgsDocs;
           test = self.packages.${system}.default.overrideAttrs (drvAttrs: {
             postCheck = drvAttrs.postCheck or "" + ''
               ${pkgs.rustfmt}/bin/rustfmt --check src/**.rs

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ enum DocItemOrLegacy {
 }
 
 /// Returns a rfc145 doc-comment if one is present
-pub fn retrieve_doc_comment(node: &SyntaxNode, shift_headings_by: Option<u8>) -> Option<String> {
+pub fn retrieve_doc_comment(node: &SyntaxNode, shift_headings_by: Option<usize>) -> Option<String> {
     let doc_comment = get_expr_docs(node);
 
     doc_comment.map(|doc_comment| {

--- a/src/snapshots/nixdoc__test__commonmark.snap
+++ b/src/snapshots/nixdoc__test__commonmark.snap
@@ -1,0 +1,154 @@
+---
+source: src/test.rs
+expression: output
+---
+# Heading 1
+
+This Markdown includes a variety of elements that you might find in a document parsed to an AST by a Markdown parser following the CommonMark specification. 
+Feel free to modify or expand upon it based on your specific needs or to explore additional Markdown features.
+
+## Heading 2
+
+### Heading 3
+
+#### Heading 4
+
+##### Heading 5
+
+This is a paragraph with some **bold text** and _italic text_.
+
+> This is a blockquote.
+
+- This is
+- an unordered
+- list
+
+1. This is
+2. an ordered
+3. list
+
+`Inline code` spans are also supported.
+
+```bash {#example .class}
+# This is a code block
+echo "Hello, Markdown!"
+```
+
+Here is a horizontal rule:
+
+---
+
+### Links and Images
+
+[This is a link](https://example.com)
+
+![This is an image](https://example.com/image.png "Image Title")
+
+### Tables
+
+| Syntax    | Description |
+| --------- | ----------- |
+| Header    | Title       |
+| Paragraph | Text        |
+
+### Footnotes
+
+Here is a text with a footnote[^1].
+
+[^1]: This is the footnote.
+
+### Inline HTML
+
+<b>This is bold text using HTML</b>
+
+<div style="color: red;">
+  This is a div with red text.
+</div>
+
+### Task list
+
+- [x] This is a completed task
+- [ ] This is an uncompleted task
+
+### Markdown-it-py extensions
+
+### Fenced div with attributes
+
+::: {#customDiv .customStyle key="value"}
+This is a Pandoc-style fenced div with attributes.
+:::
+
+:::{#ex-makeScope .example}
+#### Create an interdependent package set on top of `pkgs`
+
+The functions in `foo.nix` and `bar.nix` can depend on each other, in the sense that `foo.nix` can contain a function that expects `bar` as an attribute in its argument.
+
+```nix
+let
+    pkgs = import <nixpkgs> { };
+in
+pkgs.lib.makeScope pkgs.newScope (self: {
+    foo = self.callPackage ./foo.nix { };
+    bar = self.callPackage ./bar.nix { };
+})
+```
+
+evaluates to
+
+```nix
+{
+    callPackage = «lambda»;
+    newScope = «lambda»;
+    overrideScope = «lambda»;
+    packages = «lambda»;
+    foo = «derivation»;
+    bar = «derivation»;
+}
+```
+:::
+
+### Heading anchors
+
+#### Simple {#some-id}
+
+#### With attributes {#some-other-id .customClass style="color:blue;"}
+
+This heading includes both an anchor and CSS attributes.
+
+### Definition List
+
+Term 1
+:   Definition 1
+
+Term 2
+:   Definition 2 with a **bold** aspect.
+
+Parent Term
+:   Parent Definition
+
+    Nested Term 1
+    :   Nested Definition 1
+
+    Nested Term 2
+    :   Nested Definition 2
+
+::: {.important}
+**Note:**
+:   This is an important note inside a custom styled div.
+:::
+
+### Codeblocks
+
+```python
+# This is a Python code example
+def hello_world():
+    print("Hello, world!")
+```
+
+Codeblock with  attributes
+
+    ```python {#codeExample .highlighted style="background-color: #f0f0f0;"}
+    # This is a Python code example
+    def hello_world():
+        print("Hello, world!")
+    ```

--- a/src/snapshots/nixdoc__test__doc_comment.snap
+++ b/src/snapshots/nixdoc__test__doc_comment.snap
@@ -20,8 +20,6 @@ This is a parsed example
 
 doc comment in markdown format
 
-
-
 ## `lib.debug.foo` {#function-library-lib.debug.foo}
 
 Comment

--- a/src/snapshots/nixdoc__test__doc_comment_no_duplicate_arguments.snap
+++ b/src/snapshots/nixdoc__test__doc_comment_no_duplicate_arguments.snap
@@ -18,20 +18,14 @@ nixdoc comment
 
 Doc-comment
 
-
-
 ## `lib.debug.multiple` {#function-library-lib.debug.multiple}
 
 Doc-comment
 
-
-
 ## `lib.debug.argumentTest` {#function-library-lib.debug.argumentTest}
 
-Doc-comment before the lamdba causes the whole
+Doc-comment before the lamdba causes the whole 
 lambda including its arguments to switch to doc-comments ONLY rendering
-
-
 
 ## `lib.debug.legacyArgumentTest` {#function-library-lib.debug.legacyArgumentTest}
 

--- a/src/snapshots/nixdoc__test__headings.snap
+++ b/src/snapshots/nixdoc__test__headings.snap
@@ -6,7 +6,19 @@ expression: output
 
 #### h2-heading
 
+3 leading whitespaces are okay for headings
+
+#### h2 heading
+
+    # code block
+
+
 #### h2-heading-with-id {#some-id}
+
+Indented code block
+
+    # Code comment
+    a = 1;
 
 ##### h3-heading
 
@@ -22,6 +34,8 @@ map a from b -> 1
 ```
 
 ##### indented (0-3) fences
+
+3 leading whitespaces are okay for code fences
 
   ``` lang info
 # Some pseudocode

--- a/src/snapshots/nixdoc__test__headings.snap
+++ b/src/snapshots/nixdoc__test__headings.snap
@@ -21,6 +21,27 @@ expression: output
 map a from b -> 1
 ```
 
+##### indented (0-3) fences
+
+  ``` lang info
+# Some pseudocode
+map a from b -> 1
+   ```
+
+##### indented (0-3) fences asymmetric
+
+```
+# Some pseudocode
+map a from b -> 1
+   ```
+
+##### More closing fences than opening
+
+````
+# Some pseudocode
+map a from b -> 1
+```````
+
 ##### Some heading
 
 ````nix
@@ -53,7 +74,6 @@ Nested tilde fences
 # A comment ^
 foo
 ~~~~~
-
 
 ###### h5-heading
 

--- a/src/snapshots/nixdoc__test__headings.snap
+++ b/src/snapshots/nixdoc__test__headings.snap
@@ -10,29 +10,64 @@ expression: output
 
 ##### h3-heading
 
-``` nix
+```nix
 # A comment should not be shifted
 ```
 
-    # Some pseudocode
-    map a from b -> 1
+##### annother heading
 
-```` nix
+```
+# Some pseudocode
+map a from b -> 1
+```
+
+##### Some heading
+
+````nix
 /**
    ```nix
    # A nested comment should not be shifted
    ```
 */
 1
+# A comment
 ````
 
 ###### h4-heading
 
-This should be h6
+Nested tilde fences
+
+~~~~~nix
+/*
+   ~~~~nix
+      /**
+         ~~~nix
+            # A nested comment should not be shifted
+            42
+         ~~~
+      */
+      1
+      # A nested comment ^
+   ~~~~
+*/
+# A comment ^
+foo
+~~~~~
+
 
 ###### h5-heading
 
-This should be h6 as well
+Mixed fences
+
+~~~nix
+/**
+   ```nix
+   # A nested comment should not be shifted
+   ```
+*/
+1
+# A comment
+~~~
 
 ###### h6-heading
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -151,6 +151,15 @@ fn test_doc_comment() {
 }
 
 #[test]
+fn test_commonmark() {
+    let src = fs::read_to_string("test/commonmark.md").unwrap();
+
+    let output = shift_headings(&src, 0);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn test_headings() {
     let src = fs::read_to_string("test/headings.md").unwrap();
 

--- a/test/commonmark.md
+++ b/test/commonmark.md
@@ -1,0 +1,150 @@
+# Heading 1
+
+This Markdown includes a variety of elements that you might find in a document parsed to an AST by a Markdown parser following the CommonMark specification. 
+Feel free to modify or expand upon it based on your specific needs or to explore additional Markdown features.
+
+## Heading 2
+
+### Heading 3
+
+#### Heading 4
+
+##### Heading 5
+
+This is a paragraph with some **bold text** and _italic text_.
+
+> This is a blockquote.
+
+- This is
+- an unordered
+- list
+
+1. This is
+2. an ordered
+3. list
+
+`Inline code` spans are also supported.
+
+```bash {#example .class}
+# This is a code block
+echo "Hello, Markdown!"
+```
+
+Here is a horizontal rule:
+
+---
+
+### Links and Images
+
+[This is a link](https://example.com)
+
+![This is an image](https://example.com/image.png "Image Title")
+
+### Tables
+
+| Syntax    | Description |
+| --------- | ----------- |
+| Header    | Title       |
+| Paragraph | Text        |
+
+### Footnotes
+
+Here is a text with a footnote[^1].
+
+[^1]: This is the footnote.
+
+### Inline HTML
+
+<b>This is bold text using HTML</b>
+
+<div style="color: red;">
+  This is a div with red text.
+</div>
+
+### Task list
+
+- [x] This is a completed task
+- [ ] This is an uncompleted task
+
+### Markdown-it-py extensions
+
+### Fenced div with attributes
+
+::: {#customDiv .customStyle key="value"}
+This is a Pandoc-style fenced div with attributes.
+:::
+
+:::{#ex-makeScope .example}
+#### Create an interdependent package set on top of `pkgs`
+
+The functions in `foo.nix` and `bar.nix` can depend on each other, in the sense that `foo.nix` can contain a function that expects `bar` as an attribute in its argument.
+
+```nix
+let
+    pkgs = import <nixpkgs> { };
+in
+pkgs.lib.makeScope pkgs.newScope (self: {
+    foo = self.callPackage ./foo.nix { };
+    bar = self.callPackage ./bar.nix { };
+})
+```
+
+evaluates to
+
+```nix
+{
+    callPackage = «lambda»;
+    newScope = «lambda»;
+    overrideScope = «lambda»;
+    packages = «lambda»;
+    foo = «derivation»;
+    bar = «derivation»;
+}
+```
+:::
+
+### Heading anchors
+
+#### Simple {#some-id}
+
+#### With attributes {#some-other-id .customClass style="color:blue;"}
+
+This heading includes both an anchor and CSS attributes.
+
+### Definition List
+
+Term 1
+:   Definition 1
+
+Term 2
+:   Definition 2 with a **bold** aspect.
+
+Parent Term
+:   Parent Definition
+
+    Nested Term 1
+    :   Nested Definition 1
+
+    Nested Term 2
+    :   Nested Definition 2
+
+::: {.important}
+**Note:**
+:   This is an important note inside a custom styled div.
+:::
+
+### Codeblocks
+
+```python
+# This is a Python code example
+def hello_world():
+    print("Hello, world!")
+```
+
+Codeblock with  attributes
+
+    ```python {#codeExample .highlighted style="background-color: #f0f0f0;"}
+    # This is a Python code example
+    def hello_world():
+        print("Hello, world!")
+    ```

--- a/test/headings.md
+++ b/test/headings.md
@@ -2,7 +2,19 @@
 
 ## h2-heading
 
+3 leading whitespaces are okay for headings
+
+   ## h2 heading
+
+    # code block
+
+
 ## h2-heading-with-id {#some-id}
+
+Indented code block
+
+    # Code comment
+    a = 1;
 
 ### h3-heading
 
@@ -18,6 +30,8 @@ map a from b -> 1
 ```
 
 ### indented (0-3) fences
+
+3 leading whitespaces are okay for code fences
 
   ``` lang info
 # Some pseudocode

--- a/test/headings.md
+++ b/test/headings.md
@@ -10,10 +10,14 @@
 # A comment should not be shifted
 ```
 
+### annother heading
+
 ```
 # Some pseudocode
 map a from b -> 1
 ```
+
+### Some heading
 
 ````nix
 /**
@@ -22,15 +26,44 @@ map a from b -> 1
    ```
 */
 1
+# A comment
 ````
 
 #### h4-heading
 
-This should be h6
+Nested tilde fences
+
+~~~~~nix
+/*
+   ~~~~nix
+      /**
+         ~~~nix
+            # A nested comment should not be shifted
+            42
+         ~~~
+      */
+      1
+      # A nested comment ^
+   ~~~~
+*/
+# A comment ^
+foo
+~~~~~
+
 
 ##### h5-heading
 
-This should be h6 as well
+Mixed fences
+
+~~~nix
+/**
+   ```nix
+   # A nested comment should not be shifted
+   ```
+*/
+1
+# A comment
+~~~
 
 ###### h6-heading
 

--- a/test/headings.md
+++ b/test/headings.md
@@ -17,6 +17,27 @@
 map a from b -> 1
 ```
 
+### indented (0-3) fences
+
+  ``` lang info
+# Some pseudocode
+map a from b -> 1
+   ```
+
+### indented (0-3) fences asymmetric
+
+```
+# Some pseudocode
+map a from b -> 1
+   ```
+
+### More closing fences than opening
+
+````
+# Some pseudocode
+map a from b -> 1
+```````
+
 ### Some heading
 
 ````nix
@@ -49,7 +70,6 @@ Nested tilde fences
 # A comment ^
 foo
 ~~~~~
-
 
 ##### h5-heading
 


### PR DESCRIPTION
This PR fixes the problems that where introduced with using any commonmark parser to shift the headings.

Currently nixdoc cannot be used to build the nixpkgs manual. This PR fixes that and also ensures that it remains buildable.

Even though headings might be detected and can be operated on, it became nearly impossible to serialize the parsed tokens/ast of any parser (the rest of the document).  Any parser must support ALL underlying extensions that we use in nixpkgs docs. OR alternatively any parser should preserve whitespace and formatting, but i couldnt find any parser amongst the rust ecosystem with such properties.

## Solution

The solution now involves to manually track whether we are inside or outside of code-blocks and shift only headings that are not inside a code block and start right at the beginning of the line. 

- A rather simple state tracking should be a pretty solid solution for the problem.

- Also added an additional check to the flake where we build the nixpkgs manual against the current state of nixdoc.

ping @infinisil 

## Limitations

https://spec.commonmark.org/0.28/#fenced-code-blocks

Commonmark also specifies how **unclosed codeblocks behave**. We don't support unclosed code blocks.

````md
- item   
    ```nix
    1
````
 