### PR TITLE
Allow empty prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Version 3.0.7
+
+Add support for empty prefix flags.
+Allows for improved generic usage in nixpkgs/lib and other projects.
+
+Empty prefix is now possible.
+Issue: https://github.com/nix-community/nixdoc/issues/119 by @roberth
+
+by @hsjobeki;
+
+in https://github.com/nix-community/nixdoc/pull/122.
+
 ## Version 3.0.6
 
 Exposes the package recipe under `recipes.default` so it can easily be re-used.

--- a/src/commonmark.rs
+++ b/src/commonmark.rs
@@ -127,20 +127,35 @@ pub struct ManualEntry {
 }
 
 impl ManualEntry {
+    /// Generate the identifier and title for CommonMark.
+    /// title is the human-readable name of the function.
+    /// ident is used as URL Encoded link to the function and has thus stricter rules (i.e. "' " in "lib.map' "  is not allowed).
+    pub(crate) fn get_ident_title(&self) -> (String, String) {
+        let name_prime = self.name.replace('\'', "-prime");
+
+        let ident = vec![&self.prefix, &self.category, &name_prime]
+            .into_iter()
+            .filter(|x| !x.is_empty())
+            .cloned()
+            .collect::<Vec<String>>()
+            .join(".");
+
+        let title = vec![&self.prefix, &self.category, &self.name]
+            .into_iter()
+            .filter(|x| !x.is_empty())
+            .cloned()
+            .collect::<Vec<String>>()
+            .join(".");
+
+        (ident, title)
+    }
     /// Write a single CommonMark entry for a documented Nix function.
     pub fn write_section<W: Write>(
         self,
         locs: &HashMap<String, String>,
         writer: &mut W,
     ) -> Result<()> {
-        let title = format!("{}.{}.{}", self.prefix, self.category, self.name);
-        let ident = format!(
-            "{}.{}.{}",
-            self.prefix,
-            self.category,
-            self.name.replace('\'', "-prime")
-        );
-
+        let (ident, title) = self.get_ident_title();
         writeln!(writer, "## `{}` {{#function-library-{}}}\n", title, ident)?;
 
         // <subtitle> (type signature)

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,7 +3,7 @@ use std::fs;
 
 use std::io::Write;
 
-use crate::{collect_entries, format::shift_headings, retrieve_description};
+use crate::{collect_entries, format::shift_headings, retrieve_description, ManualEntry};
 
 #[test]
 fn test_main() {
@@ -208,4 +208,22 @@ fn test_doc_comment_no_duplicate_arguments() {
     let output = String::from_utf8(output).expect("not utf8");
 
     insta::assert_snapshot!(output);
+}
+
+#[test]
+fn test_empty_prefix() {
+    let test_entry = ManualEntry {
+        args: vec![],
+        category: "test".to_string(),
+        description: vec![],
+        example: None,
+        fn_type: None,
+        name: "mapSimple'".to_string(),
+        prefix: "".to_string(),
+    };
+
+    let (ident, title) = test_entry.get_ident_title();
+
+    assert_eq!(ident, "test.mapSimple-prime");
+    assert_eq!(title, "test.mapSimple'");
 }


### PR DESCRIPTION
Requires #121 to be merged first.

This closes #119 

empty prefix or catgeory is possible when this gets merged