### PR TITLE
fix: skip attrsets in patterns

### DIFF
--- a/src/snapshots/nixdoc__test__patterns.snap
+++ b/src/snapshots/nixdoc__test__patterns.snap
@@ -1,0 +1,7 @@
+---
+source: src/test.rs
+expression: output
+---
+## `lib.debug.iAmTopLevel` {#function-library-lib.debug.iAmTopLevel}
+
+This binding is in the top-level attrset

--- a/src/test.rs
+++ b/src/test.rs
@@ -227,3 +227,22 @@ fn test_empty_prefix() {
     assert_eq!(ident, "test.mapSimple-prime");
     assert_eq!(title, "test.mapSimple'");
 }
+
+#[test]
+fn test_patterns() {
+    let mut output = Vec::new();
+    let src = fs::read_to_string("test/patterns.nix").unwrap();
+    let nix = rnix::Root::parse(&src).ok().expect("failed to parse input");
+    let prefix = "lib";
+    let category = "debug";
+
+    for entry in collect_entries(nix, prefix, category) {
+        entry
+            .write_section(&Default::default(), &mut output)
+            .expect("Failed to write section")
+    }
+
+    let output = String::from_utf8(output).expect("not utf8");
+
+    insta::assert_snapshot!(output);
+}

--- a/test/patterns.nix
+++ b/test/patterns.nix
@@ -1,0 +1,13 @@
+{ 
+  pkgs ? import <nixpkgs>
+    # | This attrset must be skipped -- it is not the top-level attrset
+    # ↓ even though it comes first!
+    {   }
+}:
+
+{
+  /** 
+    This binding is in the top-level attrset
+  */
+  iAmTopLevel = null;
+}


### PR DESCRIPTION
Fixes parsing of docs in this kind of code:

```nix
{ 
  pkgs ? import <nixpkgs>
    # | This attrset must be skipped -- it is not the top-level attrset
    # ↓ even though it comes first!
    {   }
}:

{
  /** 
    This binding is in the top-level attrset
  */
  iAmTopLevel = null;
}
```