### PR TITLE
feat: Minimal format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Upcoming release
+
+Add `--anchor-prefix` to remove or customize the `function-library-` prefix.
+
+A header won't be rendered when `--description` and `--category` are empty.
+This makes the generated markdown more flexible for inclusion in other documents.
+
 ## Version 3.0.8
 
 Add `--json-output`, providing a JSON representation of the documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 3.0.8
+
+Add `--json-output`, providing a JSON representation of the documentation.
+
+Fix: attrsets in patterns are now skipped correctly.
+
 ## Version 3.0.7
 
 Add support for empty prefix flags.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ The following is an example of markdown documentation for new and current users 
 
 > Note: Within nixpkgs the convention of using [definition-lists](https://www.markdownguide.org/extended-syntax/#definition-lists) for documenting arguments has been established.
 
+## Usage
+
+Refer to `nixdoc --help` for the most up-to-date usage information.
+
+For a minimal format, suitable for inclusion into a dedicated documentation page, use:
+
+```sh
+nixdoc --file lib.nix --category "" --description "" --prefix "" --anchor-prefix "" >lib.md
+```
 
 ## Custom nixdoc format (Legacy)
 

--- a/src/commonmark.rs
+++ b/src/commonmark.rs
@@ -158,11 +158,17 @@ impl ManualEntry {
     }
 
     /// Write a single CommonMark entry for a documented Nix function.
-    pub fn write_section(self, output: &mut String) -> String {
+    ///
+    /// # Arguments
+    ///
+    /// - `anchor_prefix`: The prefix to use for the anchor links.
+    ///   In Nixpkgs this would be "function-library-".
+    /// - `output`: The output string to append the CommonMark onto.
+    pub fn write_section(self, anchor_prefix: &str, output: &mut String) -> String {
         let (ident, title) = self.get_ident_title();
         output.push_str(&format!(
-            "## `{}` {{#function-library-{}}}\n\n",
-            title, ident
+            "## `{}` {{#{}{}}}\n\n",
+            title, anchor_prefix, ident
         ));
 
         // <subtitle> (type signature)
@@ -193,8 +199,8 @@ impl ManualEntry {
         // examples, how can this be achieved automatically?
         if let Some(example) = &self.example {
             output.push_str(&format!(
-                "::: {{.example #function-library-example-{}}}\n",
-                ident
+                "::: {{.example #{}example-{}}}\n",
+                anchor_prefix, ident
             ));
             output.push_str(&format!("# `{}` usage example\n\n", title));
             output.push_str(&format!("```nix\n{}\n```\n:::\n\n", example.trim()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,9 @@ struct Options {
     #[arg(short, long, default_value_t = String::from("lib"))]
     prefix: String,
 
+    #[arg(long, default_value_t = String::from("function-library-"))]
+    anchor_prefix: String,
+
     /// Whether to output JSON.
     #[arg(short, long, default_value_t = false)]
     json_output: bool,
@@ -310,6 +313,9 @@ fn collect_entries(
 }
 
 fn retrieve_description(nix: &rnix::Root, description: &str, category: &str) -> String {
+    if description.is_empty() && category.is_empty() {
+        return String::new();
+    }
     format!(
         "# {} {{#sec-functions-library-{}}}\n{}\n",
         description,
@@ -351,7 +357,7 @@ fn main_with_options(opts: Options) -> String {
         let mut output = description + "\n";
 
         for entry in entries {
-            entry.write_section(&mut output);
+            entry.write_section(opts.anchor_prefix.as_str(), &mut output);
         }
         output
     }

--- a/src/snapshots/nixdoc__test__main_minimal.snap
+++ b/src/snapshots/nixdoc__test__main_minimal.snap
@@ -1,0 +1,1561 @@
+---
+source: src/test.rs
+expression: output
+---
+## `concatStrings` {#concatStrings}
+
+**Type**: `concatStrings :: [string] -> string`
+
+Concatenate a list of strings.
+
+::: {.example #example-concatStrings}
+# `concatStrings` usage example
+
+```nix
+concatStrings ["foo" "bar"]
+=> "foobar"
+```
+:::
+
+## `concatMapStrings` {#concatMapStrings}
+
+**Type**: `concatMapStrings :: (a -> string) -> [a] -> string`
+
+Map a function over a list and concatenate the resulting strings.
+
+`f`
+
+: Function argument
+
+
+`list`
+
+: Function argument
+
+
+::: {.example #example-concatMapStrings}
+# `concatMapStrings` usage example
+
+```nix
+concatMapStrings (x: "a" + x) ["foo" "bar"]
+=> "afooabar"
+```
+:::
+
+## `concatImapStrings` {#concatImapStrings}
+
+**Type**: `concatImapStrings :: (int -> a -> string) -> [a] -> string`
+
+Like `concatMapStrings` except that the f functions also gets the
+position as a parameter.
+
+`f`
+
+: Function argument
+
+
+`list`
+
+: Function argument
+
+
+::: {.example #example-concatImapStrings}
+# `concatImapStrings` usage example
+
+```nix
+concatImapStrings (pos: x: "${toString pos}-${x}") ["foo" "bar"]
+=> "1-foo2-bar"
+```
+:::
+
+## `intersperse` {#intersperse}
+
+**Type**: `intersperse :: a -> [a] -> [a]`
+
+Place an element between each element of a list
+
+`separator`
+
+: Separator to add between elements
+
+
+`list`
+
+: Input list
+
+
+::: {.example #example-intersperse}
+# `intersperse` usage example
+
+```nix
+intersperse "/" ["usr" "local" "bin"]
+=> ["usr" "/" "local" "/" "bin"].
+```
+:::
+
+## `concatStringsSep` {#concatStringsSep}
+
+**Type**: `concatStringsSep :: string -> [string] -> string`
+
+Concatenate a list of strings with a separator between each element
+
+::: {.example #example-concatStringsSep}
+# `concatStringsSep` usage example
+
+```nix
+concatStringsSep "/" ["usr" "local" "bin"]
+=> "usr/local/bin"
+```
+:::
+
+## `concatMapStringsSep` {#concatMapStringsSep}
+
+**Type**: `concatMapStringsSep :: string -> (a -> string) -> [a] -> string`
+
+Maps a function over a list of strings and then concatenates the
+result with the specified separator interspersed between
+elements.
+
+`sep`
+
+: Separator to add between elements
+
+
+`f`
+
+: Function to map over the list
+
+
+`list`
+
+: List of input strings
+
+
+::: {.example #example-concatMapStringsSep}
+# `concatMapStringsSep` usage example
+
+```nix
+concatMapStringsSep "-" (x: toUpper x)  ["foo" "bar" "baz"]
+=> "FOO-BAR-BAZ"
+```
+:::
+
+## `concatImapStringsSep` {#concatImapStringsSep}
+
+**Type**: `concatIMapStringsSep :: string -> (int -> a -> string) -> [a] -> string`
+
+Same as `concatMapStringsSep`, but the mapping function
+additionally receives the position of its argument.
+
+`sep`
+
+: Separator to add between elements
+
+
+`f`
+
+: Function that receives elements and their positions
+
+
+`list`
+
+: List of input strings
+
+
+::: {.example #example-concatImapStringsSep}
+# `concatImapStringsSep` usage example
+
+```nix
+concatImapStringsSep "-" (pos: x: toString (x / pos)) [ 6 6 6 ]
+=> "6-3-2"
+```
+:::
+
+## `concatLines` {#concatLines}
+
+**Type**: `concatLines :: [string] -> string`
+
+Concatenate a list of strings, adding a newline at the end of each one.
+Defined as `concatMapStrings (s: s + "\n")`.
+
+::: {.example #example-concatLines}
+# `concatLines` usage example
+
+```nix
+concatLines [ "foo" "bar" ]
+=> "foo\nbar\n"
+```
+:::
+
+## `makeSearchPath` {#makeSearchPath}
+
+**Type**: `makeSearchPath :: string -> [string] -> string`
+
+Construct a Unix-style, colon-separated search path consisting of
+the given `subDir` appended to each of the given paths.
+
+`subDir`
+
+: Directory name to append
+
+
+`paths`
+
+: List of base paths
+
+
+::: {.example #example-makeSearchPath}
+# `makeSearchPath` usage example
+
+```nix
+makeSearchPath "bin" ["/root" "/usr" "/usr/local"]
+=> "/root/bin:/usr/bin:/usr/local/bin"
+makeSearchPath "bin" [""]
+=> "/bin"
+```
+:::
+
+## `makeSearchPathOutput` {#makeSearchPathOutput}
+
+**Type**: `string -> string -> [package] -> string`
+
+Construct a Unix-style search path by appending the given
+`subDir` to the specified `output` of each of the packages. If no
+output by the given name is found, fallback to `.out` and then to
+the default.
+
+`output`
+
+: Package output to use
+
+
+`subDir`
+
+: Directory name to append
+
+
+`pkgs`
+
+: List of packages
+
+
+::: {.example #example-makeSearchPathOutput}
+# `makeSearchPathOutput` usage example
+
+```nix
+makeSearchPathOutput "dev" "bin" [ pkgs.openssl pkgs.zlib ]
+=> "/nix/store/9rz8gxhzf8sw4kf2j2f1grr49w8zx5vj-openssl-1.0.1r-dev/bin:/nix/store/wwh7mhwh269sfjkm6k5665b5kgp7jrk2-zlib-1.2.8/bin"
+```
+:::
+
+## `makeLibraryPath` {#makeLibraryPath}
+
+Construct a library search path (such as RPATH) containing the
+libraries for a set of packages
+
+::: {.example #example-makeLibraryPath}
+# `makeLibraryPath` usage example
+
+```nix
+makeLibraryPath [ "/usr" "/usr/local" ]
+=> "/usr/lib:/usr/local/lib"
+pkgs = import <nixpkgs> { }
+makeLibraryPath [ pkgs.openssl pkgs.zlib ]
+=> "/nix/store/9rz8gxhzf8sw4kf2j2f1grr49w8zx5vj-openssl-1.0.1r/lib:/nix/store/wwh7mhwh269sfjkm6k5665b5kgp7jrk2-zlib-1.2.8/lib"
+```
+:::
+
+## `makeBinPath` {#makeBinPath}
+
+Construct a binary search path (such as $PATH) containing the
+binaries for a set of packages.
+
+::: {.example #example-makeBinPath}
+# `makeBinPath` usage example
+
+```nix
+makeBinPath ["/root" "/usr" "/usr/local"]
+=> "/root/bin:/usr/bin:/usr/local/bin"
+```
+:::
+
+## `normalizePath` {#normalizePath}
+
+**Type**: `normalizePath :: string -> string`
+
+Normalize path, removing extraneous /s
+
+`s`
+
+: Function argument
+
+
+::: {.example #example-normalizePath}
+# `normalizePath` usage example
+
+```nix
+normalizePath "/a//b///c/"
+=> "/a/b/c/"
+```
+:::
+
+## `optionalString` {#optionalString}
+
+**Type**: `optionalString :: bool -> string -> string`
+
+Depending on the boolean `cond', return either the given string
+or the empty string. Useful to concatenate against a bigger string.
+
+`cond`
+
+: Condition
+
+
+`string`
+
+: String to return if condition is true
+
+
+::: {.example #example-optionalString}
+# `optionalString` usage example
+
+```nix
+optionalString true "some-string"
+=> "some-string"
+optionalString false "some-string"
+=> ""
+```
+:::
+
+## `hasPrefix` {#hasPrefix}
+
+**Type**: `hasPrefix :: string -> string -> bool`
+
+Determine whether a string has given prefix.
+
+`pref`
+
+: Prefix to check for
+
+
+`str`
+
+: Input string
+
+
+::: {.example #example-hasPrefix}
+# `hasPrefix` usage example
+
+```nix
+hasPrefix "foo" "foobar"
+=> true
+hasPrefix "foo" "barfoo"
+=> false
+```
+:::
+
+## `hasSuffix` {#hasSuffix}
+
+**Type**: `hasSuffix :: string -> string -> bool`
+
+Determine whether a string has given suffix.
+
+`suffix`
+
+: Suffix to check for
+
+
+`content`
+
+: Input string
+
+
+::: {.example #example-hasSuffix}
+# `hasSuffix` usage example
+
+```nix
+hasSuffix "foo" "foobar"
+=> false
+hasSuffix "foo" "barfoo"
+=> true
+```
+:::
+
+## `hasInfix` {#hasInfix}
+
+**Type**: `hasInfix :: string -> string -> bool`
+
+Determine whether a string contains the given infix
+
+`infix`
+
+: Function argument
+
+
+`content`
+
+: Function argument
+
+
+::: {.example #example-hasInfix}
+# `hasInfix` usage example
+
+```nix
+hasInfix "bc" "abcd"
+=> true
+hasInfix "ab" "abcd"
+=> true
+hasInfix "cd" "abcd"
+=> true
+hasInfix "foo" "abcd"
+=> false
+```
+:::
+
+## `stringToCharacters` {#stringToCharacters}
+
+**Type**: `stringToCharacters :: string -> [string]`
+
+Convert a string to a list of characters (i.e. singleton strings).
+This allows you to, e.g., map a function over each character.  However,
+note that this will likely be horribly inefficient; Nix is not a
+general purpose programming language. Complex string manipulations
+should, if appropriate, be done in a derivation.
+Also note that Nix treats strings as a list of bytes and thus doesn't
+handle unicode.
+
+`s`
+
+: Function argument
+
+
+::: {.example #example-stringToCharacters}
+# `stringToCharacters` usage example
+
+```nix
+stringToCharacters ""
+=> [ ]
+stringToCharacters "abc"
+=> [ "a" "b" "c" ]
+stringToCharacters "🦄"
+=> [ "�" "�" "�" "�" ]
+```
+:::
+
+## `stringAsChars` {#stringAsChars}
+
+**Type**: `stringAsChars :: (string -> string) -> string -> string`
+
+Manipulate a string character by character and replace them by
+strings before concatenating the results.
+
+`f`
+
+: Function to map over each individual character
+
+
+`s`
+
+: Input string
+
+
+::: {.example #example-stringAsChars}
+# `stringAsChars` usage example
+
+```nix
+stringAsChars (x: if x == "a" then "i" else x) "nax"
+=> "nix"
+```
+:::
+
+## `charToInt` {#charToInt}
+
+**Type**: `charToInt :: string -> int`
+
+Convert char to ascii value, must be in printable range
+
+`c`
+
+: Function argument
+
+
+::: {.example #example-charToInt}
+# `charToInt` usage example
+
+```nix
+charToInt "A"
+=> 65
+charToInt "("
+=> 40
+```
+:::
+
+## `escape` {#escape}
+
+**Type**: `escape :: [string] -> string -> string`
+
+Escape occurrence of the elements of `list` in `string` by
+prefixing it with a backslash.
+
+`list`
+
+: Function argument
+
+
+::: {.example #example-escape}
+# `escape` usage example
+
+```nix
+escape ["(" ")"] "(foo)"
+=> "\\(foo\\)"
+```
+:::
+
+## `escapeC` {#escapeC}
+
+**Type**: `escapeC = [string] -> string -> string`
+
+Escape occurrence of the element of `list` in `string` by
+converting to its ASCII value and prefixing it with \\x.
+Only works for printable ascii characters.
+
+`list`
+
+: Function argument
+
+
+::: {.example #example-escapeC}
+# `escapeC` usage example
+
+```nix
+escapeC [" "] "foo bar"
+=> "foo\\x20bar"
+```
+:::
+
+## `escapeURL` {#escapeURL}
+
+**Type**: `escapeURL :: string -> string`
+
+Escape the string so it can be safely placed inside a URL
+query.
+
+::: {.example #example-escapeURL}
+# `escapeURL` usage example
+
+```nix
+escapeURL "foo/bar baz"
+=> "foo%2Fbar%20baz"
+```
+:::
+
+## `escapeShellArg` {#escapeShellArg}
+
+**Type**: `escapeShellArg :: string -> string`
+
+Quote string to be used safely within the Bourne shell.
+
+`arg`
+
+: Function argument
+
+
+::: {.example #example-escapeShellArg}
+# `escapeShellArg` usage example
+
+```nix
+escapeShellArg "esc'ape\nme"
+=> "'esc'\\''ape\nme'"
+```
+:::
+
+## `escapeShellArgs` {#escapeShellArgs}
+
+**Type**: `escapeShellArgs :: [string] -> string`
+
+Quote all arguments to be safely passed to the Bourne shell.
+
+::: {.example #example-escapeShellArgs}
+# `escapeShellArgs` usage example
+
+```nix
+escapeShellArgs ["one" "two three" "four'five"]
+=> "'one' 'two three' 'four'\\''five'"
+```
+:::
+
+## `isValidPosixName` {#isValidPosixName}
+
+**Type**: `string -> bool`
+
+Test whether the given name is a valid POSIX shell variable name.
+
+`name`
+
+: Function argument
+
+
+::: {.example #example-isValidPosixName}
+# `isValidPosixName` usage example
+
+```nix
+isValidPosixName "foo_bar000"
+=> true
+isValidPosixName "0-bad.jpg"
+=> false
+```
+:::
+
+## `toShellVar` {#toShellVar}
+
+**Type**: `string -> (string | listOf string | attrsOf string) -> string`
+
+Translate a Nix value into a shell variable declaration, with proper escaping.
+
+The value can be a string (mapped to a regular variable), a list of strings
+(mapped to a Bash-style array) or an attribute set of strings (mapped to a
+Bash-style associative array). Note that "string" includes string-coercible
+values like paths or derivations.
+
+Strings are translated into POSIX sh-compatible code; lists and attribute sets
+assume a shell that understands Bash syntax (e.g. Bash or ZSH).
+
+`name`
+
+: Function argument
+
+
+`value`
+
+: Function argument
+
+
+::: {.example #example-toShellVar}
+# `toShellVar` usage example
+
+```nix
+''
+  ${toShellVar "foo" "some string"}
+  [[ "$foo" == "some string" ]]
+''
+```
+:::
+
+## `toShellVars` {#toShellVars}
+
+**Type**: `attrsOf (string | listOf string | attrsOf string) -> string`
+
+Translate an attribute set into corresponding shell variable declarations
+using `toShellVar`.
+
+`vars`
+
+: Function argument
+
+
+::: {.example #example-toShellVars}
+# `toShellVars` usage example
+
+```nix
+let
+  foo = "value";
+  bar = foo;
+in ''
+  ${toShellVars { inherit foo bar; }}
+  [[ "$foo" == "$bar" ]]
+''
+```
+:::
+
+## `escapeNixString` {#escapeNixString}
+
+**Type**: `string -> string`
+
+Turn a string into a Nix expression representing that string
+
+`s`
+
+: Function argument
+
+
+::: {.example #example-escapeNixString}
+# `escapeNixString` usage example
+
+```nix
+escapeNixString "hello\${}\n"
+=> "\"hello\\\${}\\n\""
+```
+:::
+
+## `escapeRegex` {#escapeRegex}
+
+**Type**: `string -> string`
+
+Turn a string into an exact regular expression
+
+::: {.example #example-escapeRegex}
+# `escapeRegex` usage example
+
+```nix
+escapeRegex "[^a-z]*"
+=> "\\[\\^a-z]\\*"
+```
+:::
+
+## `escapeNixIdentifier` {#escapeNixIdentifier}
+
+**Type**: `string -> string`
+
+Quotes a string if it can't be used as an identifier directly.
+
+`s`
+
+: Function argument
+
+
+::: {.example #example-escapeNixIdentifier}
+# `escapeNixIdentifier` usage example
+
+```nix
+escapeNixIdentifier "hello"
+=> "hello"
+escapeNixIdentifier "0abc"
+=> "\"0abc\""
+```
+:::
+
+## `escapeXML` {#escapeXML}
+
+**Type**: `string -> string`
+
+Escapes a string such that it is safe to include verbatim in an XML
+document.
+
+::: {.example #example-escapeXML}
+# `escapeXML` usage example
+
+```nix
+escapeXML ''"test" 'test' < & >''
+=> "&quot;test&quot; &apos;test&apos; &lt; &amp; &gt;"
+```
+:::
+
+## `toLower` {#toLower}
+
+**Type**: `toLower :: string -> string`
+
+Converts an ASCII string to lower-case.
+
+::: {.example #example-toLower}
+# `toLower` usage example
+
+```nix
+toLower "HOME"
+=> "home"
+```
+:::
+
+## `toUpper` {#toUpper}
+
+**Type**: `toUpper :: string -> string`
+
+Converts an ASCII string to upper-case.
+
+::: {.example #example-toUpper}
+# `toUpper` usage example
+
+```nix
+toUpper "home"
+=> "HOME"
+```
+:::
+
+## `addContextFrom` {#addContextFrom}
+
+Appends string context from another string.  This is an implementation
+detail of Nix and should be used carefully.
+
+Strings in Nix carry an invisible `context` which is a list of strings
+representing store paths.  If the string is later used in a derivation
+attribute, the derivation will properly populate the inputDrvs and
+inputSrcs.
+
+`a`
+
+: Function argument
+
+
+`b`
+
+: Function argument
+
+
+::: {.example #example-addContextFrom}
+# `addContextFrom` usage example
+
+```nix
+pkgs = import <nixpkgs> { };
+addContextFrom pkgs.coreutils "bar"
+=> "bar"
+```
+:::
+
+## `splitString` {#splitString}
+
+Cut a string with a separator and produces a list of strings which
+were separated by this separator.
+
+`sep`
+
+: Function argument
+
+
+`s`
+
+: Function argument
+
+
+::: {.example #example-splitString}
+# `splitString` usage example
+
+```nix
+splitString "." "foo.bar.baz"
+=> [ "foo" "bar" "baz" ]
+splitString "/" "/usr/local/bin"
+=> [ "" "usr" "local" "bin" ]
+```
+:::
+
+## `removePrefix` {#removePrefix}
+
+**Type**: `string -> string -> string`
+
+Return a string without the specified prefix, if the prefix matches.
+
+`prefix`
+
+: Prefix to remove if it matches
+
+
+`str`
+
+: Input string
+
+
+::: {.example #example-removePrefix}
+# `removePrefix` usage example
+
+```nix
+removePrefix "foo." "foo.bar.baz"
+=> "bar.baz"
+removePrefix "xxx" "foo.bar.baz"
+=> "foo.bar.baz"
+```
+:::
+
+## `removeSuffix` {#removeSuffix}
+
+**Type**: `string -> string -> string`
+
+Return a string without the specified suffix, if the suffix matches.
+
+`suffix`
+
+: Suffix to remove if it matches
+
+
+`str`
+
+: Input string
+
+
+::: {.example #example-removeSuffix}
+# `removeSuffix` usage example
+
+```nix
+removeSuffix "front" "homefront"
+=> "home"
+removeSuffix "xxx" "homefront"
+=> "homefront"
+```
+:::
+
+## `versionOlder` {#versionOlder}
+
+Return true if string v1 denotes a version older than v2.
+
+`v1`
+
+: Function argument
+
+
+`v2`
+
+: Function argument
+
+
+::: {.example #example-versionOlder}
+# `versionOlder` usage example
+
+```nix
+versionOlder "1.1" "1.2"
+=> true
+versionOlder "1.1" "1.1"
+=> false
+```
+:::
+
+## `versionAtLeast` {#versionAtLeast}
+
+Return true if string v1 denotes a version equal to or newer than v2.
+
+`v1`
+
+: Function argument
+
+
+`v2`
+
+: Function argument
+
+
+::: {.example #example-versionAtLeast}
+# `versionAtLeast` usage example
+
+```nix
+versionAtLeast "1.1" "1.0"
+=> true
+versionAtLeast "1.1" "1.1"
+=> true
+versionAtLeast "1.1" "1.2"
+=> false
+```
+:::
+
+## `getName` {#getName}
+
+This function takes an argument that's either a derivation or a
+derivation's "name" attribute and extracts the name part from that
+argument.
+
+`x`
+
+: Function argument
+
+
+::: {.example #example-getName}
+# `getName` usage example
+
+```nix
+getName "youtube-dl-2016.01.01"
+=> "youtube-dl"
+getName pkgs.youtube-dl
+=> "youtube-dl"
+```
+:::
+
+## `getVersion` {#getVersion}
+
+This function takes an argument that's either a derivation or a
+derivation's "name" attribute and extracts the version part from that
+argument.
+
+`x`
+
+: Function argument
+
+
+::: {.example #example-getVersion}
+# `getVersion` usage example
+
+```nix
+getVersion "youtube-dl-2016.01.01"
+=> "2016.01.01"
+getVersion pkgs.youtube-dl
+=> "2016.01.01"
+```
+:::
+
+## `nameFromURL` {#nameFromURL}
+
+Extract name with version from URL. Ask for separator which is
+supposed to start extension.
+
+`url`
+
+: Function argument
+
+
+`sep`
+
+: Function argument
+
+
+::: {.example #example-nameFromURL}
+# `nameFromURL` usage example
+
+```nix
+nameFromURL "https://nixos.org/releases/nix/nix-1.7/nix-1.7-x86_64-linux.tar.bz2" "-"
+=> "nix"
+nameFromURL "https://nixos.org/releases/nix/nix-1.7/nix-1.7-x86_64-linux.tar.bz2" "_"
+=> "nix-1.7-x86"
+```
+:::
+
+## `mesonOption` {#mesonOption}
+
+**Type**:
+```
+mesonOption :: string -> string -> string
+
+@param feature The feature to be set
+@param value The desired value
+```
+
+Create a -D<feature>=<value> string that can be passed to typical Meson
+invocations.
+
+`feature`
+
+: Function argument
+
+
+`value`
+
+: Function argument
+
+
+::: {.example #example-mesonOption}
+# `mesonOption` usage example
+
+```nix
+mesonOption "engine" "opengl"
+=> "-Dengine=opengl"
+```
+:::
+
+## `mesonBool` {#mesonBool}
+
+**Type**:
+```
+mesonBool :: string -> bool -> string
+
+@param condition The condition to be made true or false
+@param flag The controlling flag of the condition
+```
+
+Create a -D<condition>={true,false} string that can be passed to typical
+Meson invocations.
+
+`condition`
+
+: Function argument
+
+
+`flag`
+
+: Function argument
+
+
+::: {.example #example-mesonBool}
+# `mesonBool` usage example
+
+```nix
+mesonBool "hardened" true
+=> "-Dhardened=true"
+mesonBool "static" false
+=> "-Dstatic=false"
+```
+:::
+
+## `mesonEnable` {#mesonEnable}
+
+**Type**:
+```
+mesonEnable :: string -> bool -> string
+
+@param feature The feature to be enabled or disabled
+@param flag The controlling flag
+```
+
+Create a -D<feature>={enabled,disabled} string that can be passed to
+typical Meson invocations.
+
+`feature`
+
+: Function argument
+
+
+`flag`
+
+: Function argument
+
+
+::: {.example #example-mesonEnable}
+# `mesonEnable` usage example
+
+```nix
+mesonEnable "docs" true
+=> "-Ddocs=enabled"
+mesonEnable "savage" false
+=> "-Dsavage=disabled"
+```
+:::
+
+## `enableFeature` {#enableFeature}
+
+Create an --{enable,disable}-<feat> string that can be passed to
+standard GNU Autoconf scripts.
+
+`enable`
+
+: Function argument
+
+
+`feat`
+
+: Function argument
+
+
+::: {.example #example-enableFeature}
+# `enableFeature` usage example
+
+```nix
+enableFeature true "shared"
+=> "--enable-shared"
+enableFeature false "shared"
+=> "--disable-shared"
+```
+:::
+
+## `enableFeatureAs` {#enableFeatureAs}
+
+Create an --{enable-<feat>=<value>,disable-<feat>} string that can be passed to
+standard GNU Autoconf scripts.
+
+`enable`
+
+: Function argument
+
+
+`feat`
+
+: Function argument
+
+
+`value`
+
+: Function argument
+
+
+::: {.example #example-enableFeatureAs}
+# `enableFeatureAs` usage example
+
+```nix
+enableFeatureAs true "shared" "foo"
+=> "--enable-shared=foo"
+enableFeatureAs false "shared" (throw "ignored")
+=> "--disable-shared"
+```
+:::
+
+## `withFeature` {#withFeature}
+
+Create an --{with,without}-<feat> string that can be passed to
+standard GNU Autoconf scripts.
+
+`with_`
+
+: Function argument
+
+
+`feat`
+
+: Function argument
+
+
+::: {.example #example-withFeature}
+# `withFeature` usage example
+
+```nix
+withFeature true "shared"
+=> "--with-shared"
+withFeature false "shared"
+=> "--without-shared"
+```
+:::
+
+## `withFeatureAs` {#withFeatureAs}
+
+Create an --{with-<feat>=<value>,without-<feat>} string that can be passed to
+standard GNU Autoconf scripts.
+
+`with_`
+
+: Function argument
+
+
+`feat`
+
+: Function argument
+
+
+`value`
+
+: Function argument
+
+
+::: {.example #example-withFeatureAs}
+# `withFeatureAs` usage example
+
+```nix
+withFeatureAs true "shared" "foo"
+=> "--with-shared=foo"
+withFeatureAs false "shared" (throw "ignored")
+=> "--without-shared"
+```
+:::
+
+## `fixedWidthString` {#fixedWidthString}
+
+**Type**: `fixedWidthString :: int -> string -> string -> string`
+
+Create a fixed width string with additional prefix to match
+required width.
+
+This function will fail if the input string is longer than the
+requested length.
+
+`width`
+
+: Function argument
+
+
+`filler`
+
+: Function argument
+
+
+`str`
+
+: Function argument
+
+
+::: {.example #example-fixedWidthString}
+# `fixedWidthString` usage example
+
+```nix
+fixedWidthString 5 "0" (toString 15)
+=> "00015"
+```
+:::
+
+## `fixedWidthNumber` {#fixedWidthNumber}
+
+Format a number adding leading zeroes up to fixed width.
+
+`width`
+
+: Function argument
+
+
+`n`
+
+: Function argument
+
+
+::: {.example #example-fixedWidthNumber}
+# `fixedWidthNumber` usage example
+
+```nix
+fixedWidthNumber 5 15
+=> "00015"
+```
+:::
+
+## `floatToString` {#floatToString}
+
+Convert a float to a string, but emit a warning when precision is lost
+during the conversion
+
+`float`
+
+: Function argument
+
+
+::: {.example #example-floatToString}
+# `floatToString` usage example
+
+```nix
+floatToString 0.000001
+=> "0.000001"
+floatToString 0.0000001
+=> trace: warning: Imprecise conversion from float to string 0.000000
+   "0.000000"
+```
+:::
+
+## `isCoercibleToString` {#isCoercibleToString}
+
+Soft-deprecated function. While the original implementation is available as
+isConvertibleWithToString, consider using isStringLike instead, if suitable.
+
+## `isConvertibleWithToString` {#isConvertibleWithToString}
+
+Check whether a list or other value can be passed to toString.
+
+Many types of value are coercible to string this way, including int, float,
+null, bool, list of similarly coercible values.
+
+`x`
+
+: Function argument
+
+
+## `isStringLike` {#isStringLike}
+
+Check whether a value can be coerced to a string.
+The value must be a string, path, or attribute set.
+
+String-like values can be used without explicit conversion in
+string interpolations and in most functions that expect a string.
+
+`x`
+
+: Function argument
+
+
+## `isStorePath` {#isStorePath}
+
+Check whether a value is a store path.
+
+`x`
+
+: Function argument
+
+
+::: {.example #example-isStorePath}
+# `isStorePath` usage example
+
+```nix
+isStorePath "/nix/store/d945ibfx9x185xf04b890y4f9g3cbb63-python-2.7.11/bin/python"
+=> false
+isStorePath "/nix/store/d945ibfx9x185xf04b890y4f9g3cbb63-python-2.7.11"
+=> true
+isStorePath pkgs.python
+=> true
+isStorePath [] || isStorePath 42 || isStorePath {} || …
+=> false
+```
+:::
+
+## `toInt` {#toInt}
+
+**Type**: `string -> int`
+
+Parse a string as an int. Does not support parsing of integers with preceding zero due to
+ambiguity between zero-padded and octal numbers. See toIntBase10.
+
+`str`
+
+: Function argument
+
+
+::: {.example #example-toInt}
+# `toInt` usage example
+
+```nix
+toInt "1337"
+=> 1337
+
+toInt "-4"
+=> -4
+
+toInt " 123 "
+=> 123
+
+toInt "00024"
+=> error: Ambiguity in interpretation of 00024 between octal and zero padded integer.
+
+toInt "3.14"
+=> error: floating point JSON numbers are not supported
+```
+:::
+
+## `toIntBase10` {#toIntBase10}
+
+**Type**: `string -> int`
+
+Parse a string as a base 10 int. This supports parsing of zero-padded integers.
+
+`str`
+
+: Function argument
+
+
+::: {.example #example-toIntBase10}
+# `toIntBase10` usage example
+
+```nix
+toIntBase10 "1337"
+=> 1337
+
+toIntBase10 "-4"
+=> -4
+
+toIntBase10 " 123 "
+=> 123
+
+toIntBase10 "00024"
+=> 24
+
+toIntBase10 "3.14"
+=> error: floating point JSON numbers are not supported
+```
+:::
+
+## `readPathsFromFile` {#readPathsFromFile}
+
+Read a list of paths from `file`, relative to the `rootPath`.
+Lines beginning with `#` are treated as comments and ignored.
+Whitespace is significant.
+
+NOTE: This function is not performant and should be avoided.
+
+::: {.example #example-readPathsFromFile}
+# `readPathsFromFile` usage example
+
+```nix
+readPathsFromFile /prefix
+  ./pkgs/development/libraries/qt-5/5.4/qtbase/series
+=> [ "/prefix/dlopen-resolv.patch" "/prefix/tzdir.patch"
+     "/prefix/dlopen-libXcursor.patch" "/prefix/dlopen-openssl.patch"
+     "/prefix/dlopen-dbus.patch" "/prefix/xdg-config-dirs.patch"
+     "/prefix/nix-profiles-library-paths.patch"
+     "/prefix/compose-search-path.patch" ]
+```
+:::
+
+## `fileContents` {#fileContents}
+
+**Type**: `fileContents :: path -> string`
+
+Read the contents of a file removing the trailing \n
+
+`file`
+
+: Function argument
+
+
+::: {.example #example-fileContents}
+# `fileContents` usage example
+
+```nix
+$ echo "1.0" > ./version
+
+fileContents ./version
+=> "1.0"
+```
+:::
+
+## `sanitizeDerivationName` {#sanitizeDerivationName}
+
+**Type**: `sanitizeDerivationName :: String -> String`
+
+Creates a valid derivation name from a potentially invalid one.
+
+::: {.example #example-sanitizeDerivationName}
+# `sanitizeDerivationName` usage example
+
+```nix
+sanitizeDerivationName "../hello.bar # foo"
+=> "-hello.bar-foo"
+sanitizeDerivationName ""
+=> "unknown"
+sanitizeDerivationName pkgs.hello
+=> "-nix-store-2g75chlbpxlrqn15zlby2dfh8hr9qwbk-hello-2.10"
+```
+:::
+
+## `levenshtein` {#levenshtein}
+
+**Type**: `levenshtein :: string -> string -> int`
+
+Computes the Levenshtein distance between two strings.
+Complexity O(n*m) where n and m are the lengths of the strings.
+Algorithm adjusted from https://stackoverflow.com/a/9750974/6605742
+
+`a`
+
+: Function argument
+
+
+`b`
+
+: Function argument
+
+
+::: {.example #example-levenshtein}
+# `levenshtein` usage example
+
+```nix
+levenshtein "foo" "foo"
+=> 0
+levenshtein "book" "hook"
+=> 1
+levenshtein "hello" "Heyo"
+=> 3
+```
+:::
+
+## `commonPrefixLength` {#commonPrefixLength}
+
+Returns the length of the prefix common to both strings.
+
+`a`
+
+: Function argument
+
+
+`b`
+
+: Function argument
+
+
+## `commonSuffixLength` {#commonSuffixLength}
+
+Returns the length of the suffix common to both strings.
+
+`a`
+
+: Function argument
+
+
+`b`
+
+: Function argument
+
+
+## `levenshteinAtMost` {#levenshteinAtMost}
+
+**Type**: `levenshteinAtMost :: int -> string -> string -> bool`
+
+Returns whether the levenshtein distance between two strings is at most some value
+Complexity is O(min(n,m)) for k <= 2 and O(n*m) otherwise
+
+::: {.example #example-levenshteinAtMost}
+# `levenshteinAtMost` usage example
+
+```nix
+levenshteinAtMost 0 "foo" "foo"
+=> true
+levenshteinAtMost 1 "foo" "boa"
+=> false
+levenshteinAtMost 2 "foo" "boa"
+=> true
+levenshteinAtMost 2 "This is a sentence" "this is a sentense."
+=> false
+levenshteinAtMost 3 "This is a sentence" "this is a sentense."
+=> true
+```
+:::

--- a/src/test.rs
+++ b/src/test.rs
@@ -11,6 +11,7 @@ use crate::{
 fn test_main() {
     let options = Options {
         prefix: String::from("lib"),
+        anchor_prefix: String::from("function-library-"),
         json_output: false,
         category: String::from("strings"),
         description: String::from("string manipulation functions"),
@@ -24,9 +25,27 @@ fn test_main() {
 }
 
 #[test]
+fn test_main_minimal() {
+    let options = Options {
+        prefix: String::from(""),
+        anchor_prefix: String::from(""),
+        json_output: false,
+        category: String::from(""),
+        description: String::from(""),
+        file: PathBuf::from("test/strings.nix"),
+        locs: Some(PathBuf::from("test/strings.json")),
+    };
+
+    let output = main_with_options(options);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn test_json_output() {
     let options = Options {
         prefix: String::from("lib"),
+        anchor_prefix: String::from("function-library-"),
         json_output: true,
         category: String::from("strings"),
         description: String::from("string manipulation functions"),
@@ -49,7 +68,7 @@ fn test_description_of_lib_debug() {
     let mut output = String::from(desc) + "\n";
 
     for entry in collect_entries(nix, prefix, category, &Default::default()) {
-        entry.write_section(&mut output);
+        entry.write_section("function-library-", &mut output);
     }
 
     insta::assert_snapshot!(output);
@@ -64,7 +83,7 @@ fn test_arg_formatting() {
     let category = "options";
 
     for entry in collect_entries(nix, prefix, category, &Default::default()) {
-        entry.write_section(&mut output);
+        entry.write_section("function-library-", &mut output);
     }
 
     insta::assert_snapshot!(output);
@@ -79,7 +98,7 @@ fn test_inherited_exports() {
     let category = "let";
 
     for entry in collect_entries(nix, prefix, category, &Default::default()) {
-        entry.write_section(&mut output);
+        entry.write_section("function-library-", &mut output);
     }
 
     insta::assert_snapshot!(output);
@@ -94,7 +113,7 @@ fn test_line_comments() {
     let category = "let";
 
     for entry in collect_entries(nix, prefix, category, &Default::default()) {
-        entry.write_section(&mut output);
+        entry.write_section("function-library-", &mut output);
     }
 
     insta::assert_snapshot!(output);
@@ -109,7 +128,7 @@ fn test_multi_line() {
     let category = "let";
 
     for entry in collect_entries(nix, prefix, category, &Default::default()) {
-        entry.write_section(&mut output);
+        entry.write_section("function-library-", &mut output);
     }
 
     insta::assert_snapshot!(output);
@@ -124,7 +143,7 @@ fn test_doc_comment() {
     let category = "debug";
 
     for entry in collect_entries(nix, prefix, category, &Default::default()) {
-        entry.write_section(&mut output);
+        entry.write_section("function-library-", &mut output);
     }
 
     insta::assert_snapshot!(output);
@@ -158,7 +177,7 @@ fn test_doc_comment_section_description() {
     let mut output = String::from(desc) + "\n";
 
     for entry in collect_entries(nix, prefix, category, &Default::default()) {
-        entry.write_section(&mut output);
+        entry.write_section("function-library-", &mut output);
     }
 
     insta::assert_snapshot!(output);
@@ -174,7 +193,7 @@ fn test_doc_comment_no_duplicate_arguments() {
     let mut output = String::from(desc) + "\n";
 
     for entry in collect_entries(nix, prefix, category, &Default::default()) {
-        entry.write_section(&mut output);
+        entry.write_section("function-library-", &mut output);
     }
 
     insta::assert_snapshot!(output);
@@ -208,7 +227,7 @@ fn test_patterns() {
     let category = "debug";
 
     for entry in collect_entries(nix, prefix, category, &Default::default()) {
-        entry.write_section(&mut output);
+        entry.write_section("function-library-", &mut output);
     }
 
     insta::assert_snapshot!(output);


### PR DESCRIPTION
When including documentation into a dedicated page, we have different needs.

- Add `--anchor-prefix` to avoid unnecessary/inaccurate `function-library-` prefix.

- Don't render a header when description and category are empty. These can be handled by the parent document when using an "include" feature of a markdown processor / site generator.

- Add this usage to the README. Good to help non-Nixpkgs users and let nixdoc grow outside of that context.

Also tested with #139