### PR TITLE
feat: resolve let-in identifier patterns to their attrset bindings

### DIFF
--- a/src/snapshots/nixdoc__test__let_ident.snap
+++ b/src/snapshots/nixdoc__test__let_ident.snap
@@ -1,0 +1,40 @@
+---
+source: src/test.rs
+expression: output
+---
+## `lib.math.add` {#function-library-lib.math.add}
+
+Adds two numbers together.
+
+### Arguments
+
+- a: The first number
+- b: The second number
+
+### Type
+
+```
+add :: Int -> Int -> Int
+```
+
+### Example
+
+```nix
+add 1 2
+=> 3
+```
+
+## `lib.math.multiply` {#function-library-lib.math.multiply}
+
+Multiplies two numbers.
+
+### Arguments
+
+- x: The first number
+- y: The second number
+
+### Type
+
+```
+multiply :: Int -> Int -> Int
+```

--- a/src/snapshots/nixdoc__test__let_ident_chained.snap
+++ b/src/snapshots/nixdoc__test__let_ident_chained.snap
@@ -1,0 +1,18 @@
+---
+source: src/test.rs
+expression: output
+---
+## `lib.math.divide` {#function-library-lib.math.divide}
+
+Divides two numbers.
+
+### Arguments
+
+- a: The dividend
+- b: The divisor
+
+### Type
+
+```
+divide :: Int -> Int -> Int
+```

--- a/src/test.rs
+++ b/src/test.rs
@@ -232,3 +232,33 @@ fn test_patterns() {
 
     insta::assert_snapshot!(output);
 }
+
+#[test]
+fn test_let_ident() {
+    let mut output = String::from("");
+    let src = fs::read_to_string("test/let-ident.nix").unwrap();
+    let nix = rnix::Root::parse(&src).ok().expect("failed to parse input");
+    let prefix = "lib";
+    let category = "math";
+
+    for entry in collect_entries(nix, prefix, category, &Default::default()) {
+        entry.write_section("function-library-", &mut output);
+    }
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn test_let_ident_chained() {
+    let mut output = String::from("");
+    let src = fs::read_to_string("test/let-ident-chained.nix").unwrap();
+    let nix = rnix::Root::parse(&src).ok().expect("failed to parse input");
+    let prefix = "lib";
+    let category = "math";
+
+    for entry in collect_entries(nix, prefix, category, &Default::default()) {
+        entry.write_section("function-library-", &mut output);
+    }
+
+    insta::assert_snapshot!(output);
+}

--- a/test/let-ident-chained.nix
+++ b/test/let-ident-chained.nix
@@ -1,0 +1,33 @@
+# Test for chained let ... in identifier resolution
+# This tests the resolution of identifiers that point to other identifiers
+# alias -> exports -> attrset
+let
+  /**
+    Divides two numbers.
+
+    # Arguments
+
+    - a: The dividend
+    - b: The divisor
+
+    # Type
+
+    ```
+    divide :: Int -> Int -> Int
+    ```
+  */
+  divide = a: b: a / b;
+
+  # The actual exports attrset
+  exports = {
+    inherit divide;
+  };
+
+  # Alias points to exports
+  alias = exports;
+
+  # Another level of indirection
+  doubleAlias = alias;
+in
+  # Return via chained identifier - nixdoc should resolve alias -> exports -> attrset
+  alias

--- a/test/let-ident.nix
+++ b/test/let-ident.nix
@@ -1,0 +1,55 @@
+# Test for let ... in identifier pattern
+# This tests the resolution of identifiers that refer to attrsets defined in let bindings
+let
+  /**
+    Adds two numbers together.
+
+    # Arguments
+
+    - a: The first number
+    - b: The second number
+
+    # Type
+
+    ```
+    add :: Int -> Int -> Int
+    ```
+
+    # Example
+
+    ```nix
+    add 1 2
+    => 3
+    ```
+  */
+  add = a: b: a + b;
+
+  /**
+    Multiplies two numbers.
+
+    # Arguments
+
+    - x: The first number
+    - y: The second number
+
+    # Type
+
+    ```
+    multiply :: Int -> Int -> Int
+    ```
+  */
+  multiply = x: y: x * y;
+
+  # This is not documented (no doc comment)
+  undocumented = x: x;
+
+  # The actual exports attrset
+  exports = {
+    inherit add multiply;
+  };
+
+  # Test chained resolution: alias points to exports
+  alias = exports;
+in
+  # Return via identifier - nixdoc should resolve this to the exports attrset
+  exports


### PR DESCRIPTION
Adds support for `let ... in identifier` patterns, where the body of a let-in expression is an identifier referencing an attrset binding

## Motivation

Some Nix libraries define documented functions in let blocks and return them via an identifier:

```nix
let
  /** Doc comment */
  myFunc = x: x + 1;
  
  exports = { inherit myFunc; };
in
  exports
```

Previously, nixdoc couldn't extract documentation from these files because it only looked for attrsets directly in the let-in body, not identifier references to them.

## Changes

- Added `find_let_binding()` to locate an AttrpathValue binding by name in a let block
- Added `resolve_let_ident()` to resolve identifiers with chained resolution support (e.g., `alias = exports; in alias`)
- Updated `collect_entries()` to check if the let-in body is an identifier and resolve it before collecting bindings
- Added tests for both direct and chained identifier resolution